### PR TITLE
feat: add one-line installer + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,188 @@
-**ocs01-test**
+# ocs01 test
 
 rust cli for testing ocs01 smart contract
 
-**what it does**
+## what it does
 
--   tests all ocs01 contract methods
--   interactive menu for easy navigation
--   shows results instantly for view methods
--   handles tx signing for call methods
+- tests all ocs01 contract methods
+- interactive menu for easy navigation
+- shows results instantly for view methods
+- handles transaction signing for call methods
 
-**works on**
+## supported platforms
 
--   linux
--   macos
--   windows
+- linux
+- macos
+- windows
 
-**install rust (if not installed)**
+## quick installation
+
+install and run with a single command:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/yuwamu/ocs01-test/patch-1/install.sh | bash
+```
+
+this automated installer will:
+1. install rust if not already present
+2. clone and build the project from source
+3. set up required configuration files
+4. prompt for wallet credentials (or use existing wallet.json)
+5. automatically launch the application
+
+## manual installation
+
+### prerequisites
+
+ensure rust is installed:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source $HOME/.cargo/env
 ```
 
-**build from source**
+### build from source
 
 ```bash
-git clone https://github.com/octra-labs/ocs01-test.git
+git clone https://github.com/yuwamu/ocs01-test.git -b patch-1
 cd ocs01-test
 cargo build --release
 ```
 
-**setup**
+### configuration
+
+copy the contract interface:
 
 ```bash
-# copy contract interface
 cp EI/exec_interface.json .
 ```
 
-**required files in same directory**
+create `wallet.json` with your credentials:
 
--   wallet.json - create with your credentials
--   exec_interface.json - copy from EI/ folder
+```json
+{
+  "priv": "your_private_key_here",
+  "addr": "your_wallet_address_here",
+  "rpc": "https://octra.network"
+}
+```
 
-**run**
+### execution
 
-you must copy the release binary to your cli folder and also copy the EI file (execution interface file) to the same location 
+run the compiled binary:
 
-the release binary is located in this folder after successful build. 
 ```bash
 ./target/release/ocs01-test
 ```
 
-*for this task the ei file contains the interface for contract at address octBUHw585BrAMPMLQvGuWx4vqEsybYH9N7a3WNj1WBwrDn, do not modify it*
+## configuration files
 
-after running, follow the menu to interact with the contract
+two files must be present in the working directory:
+
+- **`wallet.json`** - contains your wallet credentials and rpc endpoint
+- **`exec_interface.json`** - contract interface specification (do not modify)
+
+## contract details
+
+- **address**: `octBUHw585BrAMPMLQvGuWx4vqEsybYH9N7a3WNj1WBwrDn`
+- **network**: octra network
+- **rpc endpoint**: `https://octra.network`
+
+the contract interface is pre-configured for this specific contract address. modification of the interface file may result in compatibility issues.
+
+## usage
+
+the application provides an interactive command-line interface for contract interaction:
+
+- navigate through contract methods using the menu system
+- view contract state and data in real-time
+- execute transactions with automatic signing
+- monitor transaction status and results
+
+all blockchain operations are handled transparently, including gas estimation, transaction signing, and result parsing.
+
+## project structure
+
+```
+ocs01-test/
+├── EI/
+│   └── exec_interface.json    # contract interface template
+├── src/                       # rust source code
+├── target/
+│   └── release/
+│       └── ocs01-test        # compiled executable
+├── wallet.json               # user credentials (created during setup)
+├── exec_interface.json       # active contract interface
+├── Cargo.toml               # rust project manifest
+└── install.sh               # automated installation script
+```
+
+## security considerations
+
+- store your `wallet.json` file securely
+- never share your private key with third parties
+- the private key is used for transaction signing on the blockchain
+- verify contract addresses before executing transactions
+- use the application in a secure environment when handling mainnet credentials
+
+## development
+
+to contribute to this project:
+
+1. fork the repository
+2. create a feature branch
+3. make your changes
+4. test thoroughly
+5. submit a pull request
+
+the project follows standard rust conventions and uses cargo for dependency management.etwork**: Octra Network
+- **RPC Endpoint**: `https://octra.network`
+
+The contract interface is pre-configured for this specific contract address. Modification of the interface file may result in compatibility issues.
+
+## Usage
+
+The application provides an interactive command-line interface for contract interaction:
+
+- Navigate through contract methods using the menu system
+- View contract state and data in real-time
+- Execute transactions with automatic signing
+- Monitor transaction status and results
+
+All blockchain operations are handled transparently, including gas estimation, transaction signing, and result parsing.
+
+## Project Structure
+
+```
+ocs01-test/
+├── EI/
+│   └── exec_interface.json    # Contract interface template
+├── src/                       # Rust source code
+├── target/
+│   └── release/
+│       └── ocs01-test        # Compiled executable
+├── wallet.json               # User credentials (created during setup)
+├── exec_interface.json       # Active contract interface
+├── Cargo.toml               # Rust project manifest
+└── install.sh               # Automated installation script
+```
+
+## Security Considerations
+
+- Store your `wallet.json` file securely
+- Never share your private key with third parties
+- The private key is used for transaction signing on the blockchain
+- Verify contract addresses before executing transactions
+- Use the application in a secure environment when handling mainnet credentials
+
+## Development
+
+To contribute to this project:
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test thoroughly
+5. Submit a pull request
+
+The project follows standard Rust conventions and uses Cargo for dependency management.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rust cli for testing ocs01 smart contract
 install and run with a single command:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/yuwamu/ocs01-test/patch-1/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/yuwamu/ocs01-test/ux-fixes/install.sh | bash
 ```
 
 this automated installer will:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# OCS01 Test Installer Script
+# Usage: curl -sSL https://raw.githubusercontent.com/yuwamu/ocs01-test/patch-1/install.sh | bash
+
+set -e  # Exit on any error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+print_status "Starting OCS01 Test installation..."
+
+# Check if git is installed
+if ! command_exists git; then
+    print_error "Git is not installed. Please install git first."
+    exit 1
+fi
+
+# Install Rust if not already installed
+print_status "Checking for Rust installation..."
+if ! command_exists rustc; then
+    print_status "Rust not found. Installing Rust..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    source $HOME/.cargo/env
+    print_success "Rust installed successfully!"
+else
+    print_success "Rust is already installed."
+    source $HOME/.cargo/env
+fi
+
+# Verify Rust installation
+print_status "Rust version: $(rustc --version)"
+print_status "Cargo version: $(cargo --version)"
+
+# Clone the repository
+print_status "Cloning the OCS01 test repository..."
+if [ -d "ocs01-test" ]; then
+    print_warning "Directory 'ocs01-test' already exists. Removing it..."
+    rm -rf ocs01-test
+fi
+
+git clone https://github.com/yuwamu/ocs01-test.git -b patch-1
+cd ocs01-test
+
+# Build the project
+print_status "Building the project (this may take a few minutes)..."
+cargo build --release
+
+# Setup - copy contract interface
+print_status "Setting up contract interface..."
+cp EI/exec_interface.json .
+
+# Create wallet.json with user input
+echo ""
+echo "========================================="
+print_success "Build completed successfully!"
+echo "========================================="
+echo ""
+
+# Check if wallet.json already exists
+if [ -f "wallet.json" ]; then
+    print_success "wallet.json already exists!"
+    echo "Do you want to use the existing wallet.json? (y/n):"
+    read use_existing
+    
+    if [ "$use_existing" = "y" ] || [ "$use_existing" = "Y" ]; then
+        print_success "Using existing wallet.json"
+    else
+        print_status "Creating new wallet.json file..."
+        echo "Please enter your private key:"
+        read private_key
+
+        if [ -z "$private_key" ]; then
+            print_error "Private key cannot be empty!"
+            exit 1
+        fi
+
+        echo "Please enter your wallet address:"
+        read wallet_address
+
+        if [ -z "$wallet_address" ]; then
+            print_error "Wallet address cannot be empty!"
+            exit 1
+        fi
+
+        # Create wallet.json file with all required fields
+        cat > wallet.json << EOF
+{
+  "priv": "$private_key",
+  "addr": "$wallet_address",
+  "rpc": "https://octra.network"
+}
+EOF
+
+        print_success "New wallet.json created successfully!"
+        print_status "RPC automatically set to: https://octra.network"
+    fi
+else
+    print_status "Creating wallet.json file..."
+    echo "Please enter your private key:"
+    read private_key
+
+    if [ -z "$private_key" ]; then
+        print_error "Private key cannot be empty!"
+        exit 1
+    fi
+
+    echo "Please enter your wallet address:"
+    read wallet_address
+
+    if [ -z "$wallet_address" ]; then
+        print_error "Wallet address cannot be empty!"
+        exit 1
+    fi
+
+    # Create wallet.json file with all required fields
+    cat > wallet.json << EOF
+{
+  "priv": "$private_key",
+  "addr": "$wallet_address",
+  "rpc": "https://octra.network"
+}
+EOF
+
+    print_success "wallet.json created successfully!"
+    print_status "RPC automatically set to: https://octra.network"
+fi
+
+echo ""
+echo "========================================="
+print_success "Installation Complete!"
+echo "========================================="
+echo ""
+print_status "What this CLI tool does:"
+echo "  • Tests all OCS01 contract methods"
+echo "  • Interactive menu for easy navigation"
+echo "  • Shows results instantly for view methods"
+echo "  • Handles transaction signing for call methods"
+echo ""
+print_status "Files ready:"
+echo "  ✓ exec_interface.json (contract interface - DO NOT MODIFY)"
+echo "  ✓ wallet.json (your credentials)"
+echo "  ✓ Release binary at: ./target/release/ocs01-test"
+echo ""
+print_status "Contract address: octBUHw585BrAMPMLQvGuWx4vqEsybYH9N7a3WNj1WBwrDn"
+echo ""
+print_success "Starting the application..."
+echo ""
+
+# Run the application
+./target/release/ocs01-test


### PR DESCRIPTION
# add one-line installer + docs

## what

added curl installer and readme to make onboarding brain-dead simple.

## why

current setup is ass - way too many manual steps. devs will bounce.

## changes

- `install.sh` - curl installer like rust does it
- `readme.md` - actual docs that don't suck

## before/after

**before:**
```
git clone, cargo build, copy files, create wallet.json, run binary
```

**after:**
```bash
curl -sSL https://raw.githubusercontent.com/yuwamu/ocs01-test/ux-fixes/install.sh | bash
```

## devrel impact

- zero friction onboarding
- looks legit now
- copy-paste docs that actually work
- kills basic setup support tickets
